### PR TITLE
Fixed UI crash when selecting AI-related transcription options

### DIFF
--- a/src/components/molecules/TranscriptionAccuracy.tsx
+++ b/src/components/molecules/TranscriptionAccuracy.tsx
@@ -43,6 +43,10 @@ const TranscriptionAccuracy = (): JSX.Element => {
                 return "文字起こし：高";
             case "large-distil.en":
                 return "文字起こし：英";
+            case "online-transcript":
+                return "文字起こし：オンライン";
+            case "online-chat":
+                return "AI：オンライン";
             case "small-translate-to-en":
                 return "翻訳（英）：低";
             case "medium-translate-to-en":


### PR DESCRIPTION
ヘッダーの追っかけ再生のラベル表示で `mapModel(transcriptionAccuracy)` を使用しているので、未定義の選択肢を表示すると、switch文がdefaultに落ちてErrorがスローされます。
このPRではAI（オンライン）の選択肢を定義してUIがクラッシュして真っ白になるのを防ぎます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the TranscriptionAccuracy component to support and display "online-transcript" and "online-chat" as "文字起こし：オンライン" and "AI：オンライン" respectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->