### PR TITLE
Update download URL of ggml-large.bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ unzip ./src-tauri/resources/vosk-model-ja-$VOSK_MODEL_VERSION.zip -d ./src-tauri
 rm ./src-tauri/resources/vosk-model-ja-$VOSK_MODEL_VERSION.zip
 
 # whisper
-curl -LO https://huggingface.co/datasets/ggerganov/whisper.cpp/resolve/main/ggml-large.bin
-mv ggml-large.bin ./src-tauri/resources
+curl -LO https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v1.bin
+mv ggml-large-v1.bin ./src-tauri/resources/ggml-large.bin
 ```
 
 ### voskのライブラリ更新


### PR DESCRIPTION
開発環境構築時にダウンロードするggml-large.binのURLが401 Unauthorizedを返すので、正しくダウンロードできるURLに変更しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the whisper library with a new version for enhanced performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->