### PR TITLE
macOSのシステム要件を14 Sonoma以降に更新し、依存関係のバージョンを更新。セキュリティ設定の文言を修正。

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@
 
 ## 💻 System Requirements
 
-- **Operating System**: macOS 13 Ventura or later.
+- **Operating System**: macOS 14 Sonoma or later.
 - **Processor**: Compatible with Apple Silicon (M1, M2, M3) and Intel processors.
 - **Memory**: Minimum 8GB RAM recommended for optimal performance.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -213,7 +213,7 @@
                     <!-- Badge -->
                     <div class="inline-block my-6">
                         <span class="bg-pink-100 text-pink-800 text-sm font-medium px-4 py-2 rounded-full">
-                            macOS 13+ 対応
+                            macOS 14+ 対応
                         </span>
                     </div>
 
@@ -534,7 +534,7 @@
                 今すぐ始める
             </h2>
             <p class="text-xl text-gray-600 mb-12">
-                macOS 13 Ventura以降に対応。<br>
+                macOS 14 Sonoma以降に対応。<br>
                 Apple Silicon・Intelプロセッサどちらでも動作します。
             </p>
             <div class="flex flex-col sm:flex-row justify-center gap-6">

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4170,7 +4170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4463,9 +4463,7 @@ dependencies = [
  "macos-accessibility-client",
  "mcp-sdk",
  "mistralrs",
- "objc",
- "objc-foundation",
- "objc_id",
+ "objc2 0.6.0",
  "once_cell",
  "reqwest 0.12.11",
  "rusqlite",
@@ -5668,9 +5666,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "onig"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 repository = "https://github.com/solaoi/lycoris"
 default-run = "lycoris"
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.85"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
@@ -22,7 +22,7 @@ vosk = "0.2.0"
 cpal = "0.14.1"
 dasp = "0.11"
 unicode-segmentation = "1.12.0"
-once_cell = "1.20.3"
+once_cell = "1.21.1"
 crossbeam-channel = "0.5.14"
 chrono = "0.4.40"
 hound = "3.5.1"
@@ -41,9 +41,7 @@ xcap = "0.4.0"
 # permission
 macos-accessibility-client = "0.0.1"
 core-graphics = "0.24.0"
-objc = "0.2"
-objc-foundation = "0.1"
-objc_id = "0.1"
+objc2 = "0.6.0"
 ct2rs = { version = "0.9.6", features = ["accelerate"] }
 mistralrs = { git = "https://github.com/EricLBuehler/mistral.rs.git", tag = "v0.4.0", features = [
     "metal",

--- a/src-tauri/src/module/permissions.rs
+++ b/src-tauri/src/module/permissions.rs
@@ -1,15 +1,5 @@
-extern crate objc;
-extern crate objc_foundation;
-extern crate objc_id;
-
-use objc::{
-    msg_send,
-    runtime::{Class, Object},
-    sel, sel_impl,
-};
-use objc_id::Id;
-
 use core_graphics::access::ScreenCaptureAccess;
+use objc2::{class, msg_send, runtime::AnyObject};
 use tauri::{api::dialog::confirm, Window};
 
 use super::sqlite::Sqlite;
@@ -21,10 +11,10 @@ pub fn has_accessibility_permission() -> bool {
 
 pub fn has_microphone_permission(window: Window) -> bool {
     unsafe {
-        let av_audio_session: Id<Object> =
-            msg_send![Class::get("AVAudioSession").unwrap(), sharedInstance];
-        let permission_status: i32 = msg_send![av_audio_session, recordPermission];
-        const AVAUDIO_SESSION_RECORD_PERMISSION_GRANTED: i32 = 1735552628;
+        let av_audio_session: *mut AnyObject =
+            msg_send![class!(AVAudioApplication), sharedInstance];
+        let permission_status: i64 = msg_send![av_audio_session, recordPermission];
+        const AVAUDIO_SESSION_RECORD_PERMISSION_GRANTED: i64 = 1735552628;
         let trusted = permission_status == AVAUDIO_SESSION_RECORD_PERMISSION_GRANTED;
         if !trusted {
             let func = |ok: bool| {
@@ -37,7 +27,7 @@ pub fn has_microphone_permission(window: Window) -> bool {
                     .expect("failed to open system preferences");
                 }
             };
-            confirm(Some(&window),"システム設定の\"セキュリティとプライバシー\"設定で、このアプリケーションへのアクセスを許可してください。", "\"Lycoris.app\"からマイクにアクセスしようとしています。",func);
+            confirm(Some(&window),"システム設定の\"プライバシーとセキュリティ\"設定で、このアプリケーションへのアクセスを許可してください。", "\"Lycoris.app\"からマイクにアクセスしようとしています。",func);
         }
         return trusted;
     }
@@ -62,7 +52,7 @@ pub fn has_screen_capture_permission(window: Window) -> bool {
                     .expect("failed to open system preferences");
                 }
             };
-            confirm(Some(&window),"システム設定の\"セキュリティとプライバシー\"設定で、このアプリケーションへのアクセスを許可してください。", "\"Lycoris.app\"から画面収録にアクセスしようとしています。",func);
+            confirm(Some(&window),"システム設定の\"プライバシーとセキュリティ\"設定で、このアプリケーションへのアクセスを許可してください。", "\"Lycoris.app\"から画面収録にアクセスしようとしています。",func);
         }
         return trusted;
     } else {


### PR DESCRIPTION
- AppleのAVAudioSessionのdeprecatedに対応（これにより対応OSが14以降に限定される）
https://developer.apple.com/documentation/avfaudio/avaudiosession/recordpermission-swift.property